### PR TITLE
Fix require s/Faraday/faraday/

### DIFF
--- a/lib/rolltools/utils.rb
+++ b/lib/rolltools/utils.rb
@@ -1,4 +1,4 @@
-require 'Faraday'
+require 'faraday'
 require 'json'
 
 module Rolltools::Utils


### PR DESCRIPTION
Didn't work on my system when capitalized, seems the way to go.